### PR TITLE
Made default build target use golang docker container to build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,12 @@
 SUBDIRS = pod image
 
-.PHONY: $(SUBDIRS) clean
+.PHONY: $(SUBDIRS) clean build local_build container push test
 
 all: build
 
-build: outputdir $(SUBDIRS)
-	cp */_output/* _output
+build: $(SUBDIRS)
 
-outputdir:
-	mkdir -p _output
+local_build: $(SUBDIRS)
 
 container: $(SUBDIRS)
 

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -1,0 +1,4 @@
+FROM centos:centos7
+
+COPY ./_output/image-perceiver ./image-perceiver
+CMD ["./image-perceiver"]

--- a/image/Makefile
+++ b/image/Makefile
@@ -11,23 +11,32 @@ PREFIX_CMD="gcloud"
 DOCKER_OPTS="--"
 endif
 
+OUTDIR=_output
+BINARY=image-perceiver
+
+CURRENT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+
 .PHONY: clean test
 
 all: build
 
-build:
-	mkdir -p _output
-	cd cmd && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o image-perceiver image-perceiver.go
-	cp cmd/image-perceiver _output
+build: ${OUTDIR} cmd/image-perceiver.go
+	docker run --rm -e CGO_ENABLED=0 -e GOOS=linux -e GOARCH=amd64 -v "${CURRENT_DIR}/..":/go/src/github.com/blackducksoftware/perceivers -w /go/src/github.com/blackducksoftware/perceivers/image/cmd golang go build -o ../${OUTDIR}/${BINARY} image-perceiver.go	
 
-container: build
-	cd cmd && docker build -t $(REGISTRY)/$(PREFIX)image-perceiver .
+local_build: ${OUTDIR} cmd/image-perceiver.go
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ${OUTDIR}/${BINARY} cmd/image-perceiver.go
+
+container: ${OUTDIR}/${BINARY}
+	docker build -t $(REGISTRY)/$(PREFIX)${BINARY} .
 
 push: container
-	$(PREFIX_CMD) docker $(DOCKER_OPTS) push $(REGISTRY)/$(PREFIX)image-perceiver:latest
+	$(PREFIX_CMD) docker $(DOCKER_OPTS) push $(REGISTRY)/$(PREFIX)${BINARY}:latest
 
 test:
 	go test ./pkg/...
 
 clean:
-	rm -rf _output cmd/image-perceiver
+	rm -rf ${OUTDIR}
+
+${OUTDIR}:
+	mkdir -p ${OUTDIR}

--- a/image/cmd/Dockerfile
+++ b/image/cmd/Dockerfile
@@ -1,4 +1,0 @@
-FROM centos:centos7
-
-COPY ./image-perceiver ./image-perceiver
-CMD ["./image-perceiver"]

--- a/pod/Dockerfile
+++ b/pod/Dockerfile
@@ -1,4 +1,4 @@
 FROM centos:centos7
 
-COPY ./pod-perceiver ./pod-perceiver
+COPY ./_output/pod-perceiver ./pod-perceiver
 CMD ["./pod-perceiver"]

--- a/pod/Makefile
+++ b/pod/Makefile
@@ -11,23 +11,32 @@ PREFIX_CMD="gcloud"
 DOCKER_OPTS="--"
 endif
 
+OUTDIR=_output
+BINARY=pod-perceiver
+
+CURRENT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+
 .PHONY: clean test
 
 all: build
 
-build:
-	mkdir -p _output
-	cd cmd && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o pod-perceiver pod-perceiver.go
-	cp cmd/pod-perceiver _output
+build: ${OUTDIR} cmd/pod-perceiver.go
+	docker run --rm -e CGO_ENABLED=0 -e GOOS=linux -e GOARCH=amd64 -v "${CURRENT_DIR}/..":/go/src/github.com/blackducksoftware/perceivers -w /go/src/github.com/blackducksoftware/perceivers/pod/cmd golang go build -o ../${OUTDIR}/${BINARY} pod-perceiver.go	
 
-container: build
-	cd cmd && docker build -t $(REGISTRY)/$(PREFIX)pod-perceiver .
+local_build: ${OUTDIR} cmd/pod-perceiver.go
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ${OUTDIR}/${BINARY} cmd/pod-perceiver.go
+
+container: ${OUTDIR}/${BINARY}
+	docker build -t $(REGISTRY)/$(PREFIX)${BINARY} .
 
 push: container
-	$(PREFIX_CMD) docker $(DOCKER_OPTS) push $(REGISTRY)/$(PREFIX)pod-perceiver:latest
+	$(PREFIX_CMD) docker $(DOCKER_OPTS) push $(REGISTRY)/$(PREFIX)${BINARY}:latest
 
 test:
 	go test ./pkg/...
 
 clean:
-	rm -rf _output cmd/pod-perceiver
+	rm -rf ${OUTDIR}
+
+${OUTDIR}:
+	mkdir -p ${OUTDIR}


### PR DESCRIPTION
The default build target now uses the golang docker container to build and there is also a local_build target to build using golang installed on the local system #13