### PR TITLE
add image and pod metrics

### DIFF
--- a/image/cmd/app/config.go
+++ b/image/cmd/app/config.go
@@ -55,6 +55,7 @@ type ImagePerceiverConfig struct {
 	PerceptorPort             int
 	AnnotationIntervalSeconds int
 	DumpIntervalMinutes       int
+	Port                      int
 }
 
 // GetImagePerceiverConfig returns a configuration object to configure a ImagePerceiver

--- a/image/cmd/image-perceiver.go
+++ b/image/cmd/image-perceiver.go
@@ -23,8 +23,11 @@ package main
 
 import (
 	"fmt"
+	"net/http"
+	"os"
 
 	"github.com/blackducksoftware/perceivers/image/cmd/app"
+	"github.com/prometheus/client_golang/prometheus"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -43,7 +46,18 @@ func main() {
 		panic(fmt.Errorf("failed to create image-perceiver: %v", err))
 	}
 
+	go setUpPrometheus(config.Port)
+
 	// Run the perceiver
 	stopCh := make(chan struct{})
 	perceiver.Run(stopCh)
+}
+
+func setUpPrometheus(port int) {
+	prometheus.Unregister(prometheus.NewProcessCollector(os.Getpid(), ""))
+	prometheus.Unregister(prometheus.NewGoCollector())
+	http.Handle("/metrics", prometheus.Handler())
+
+	addr := fmt.Sprintf(":%d", port)
+	http.ListenAndServe(addr, nil)
 }

--- a/image/cmd/image-perceiver.go
+++ b/image/cmd/image-perceiver.go
@@ -54,6 +54,7 @@ func main() {
 }
 
 func setUpPrometheus(port int) {
+	log.Info("setting up prometheus on port %d", port)
 	prometheus.Unregister(prometheus.NewProcessCollector(os.Getpid(), ""))
 	prometheus.Unregister(prometheus.NewGoCollector())
 	http.Handle("/metrics", prometheus.Handler())

--- a/image/pkg/mapper/image_mapper.go
+++ b/image/pkg/mapper/image_mapper.go
@@ -29,6 +29,8 @@ import (
 	perceptorapi "github.com/blackducksoftware/perceptor/pkg/api"
 
 	imageapi "github.com/openshift/api/image/v1"
+
+	metrics "github.com/blackducksoftware/perceivers/image/pkg/metrics"
 )
 
 // NewPerceptorImageFromOSImage will convert an openshift image object to a
@@ -37,6 +39,7 @@ func NewPerceptorImageFromOSImage(image *imageapi.Image) (*perceptorapi.Image, e
 	dockerRef := image.DockerImageReference
 	name, sha, err := docker.ParseImageIDString(dockerRef)
 	if err != nil {
+		metrics.RecordError("mapper", "unable to parse openshift imageID")
 		return nil, fmt.Errorf("unable to parse openshift imageID %s: %v", dockerRef, err)
 	}
 

--- a/image/pkg/metrics/metrics.go
+++ b/image/pkg/metrics/metrics.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-	log "github.com/sirupsen/logrus"
 )
 
 var httpResults *prometheus.CounterVec
@@ -36,19 +35,16 @@ var errorsCounter *prometheus.CounterVec
 // helpers
 
 func RecordError(errorStage string, errorName string) {
-	log.Infof("metrics record error %s, %s", errorStage, errorName)
 	errorsCounter.With(prometheus.Labels{"stage": errorStage, "errorName": errorName}).Inc()
 }
 
 func RecordDuration(operation string, duration time.Duration) {
-	log.Infof("record duration %s, %s", operation, duration)
 	durationsHistogram.With(prometheus.Labels{"operation": operation}).Observe(duration.Seconds())
 }
 
 // recorders
 
 func RecordHttpStats(path string, success bool) {
-	log.Infof("record http stats -- %s, %t", path, success)
 	httpResults.With(prometheus.Labels{"path": path, "result": fmt.Sprintf("%t", success)}).Inc()
 }
 

--- a/image/pkg/metrics/metrics.go
+++ b/image/pkg/metrics/metrics.go
@@ -65,7 +65,7 @@ func init() {
 			Subsystem: "image_perceiver",
 			Name:      "timings",
 			Help:      "time durations of image perceiver operations",
-			Buckets:   prometheus.ExponentialBuckets(0.0001, 2, 20),
+			Buckets:   prometheus.ExponentialBuckets(0.0000001, 2, 30),
 		},
 		[]string{"operation"})
 

--- a/image/pkg/metrics/metrics.go
+++ b/image/pkg/metrics/metrics.go
@@ -65,7 +65,7 @@ func init() {
 			Subsystem: "image_perceiver",
 			Name:      "timings",
 			Help:      "time durations of image perceiver operations",
-			Buckets:   prometheus.ExponentialBuckets(0.25, 2, 20),
+			Buckets:   prometheus.ExponentialBuckets(0.0001, 2, 20),
 		},
 		[]string{"operation"})
 

--- a/image/pkg/metrics/metrics.go
+++ b/image/pkg/metrics/metrics.go
@@ -1,0 +1,82 @@
+/*
+Copyright (C) 2018 Synopsys, Inc.
+
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements. See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership. The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
+package metrics
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var httpResults *prometheus.CounterVec
+var durationsHistogram *prometheus.HistogramVec
+var errorsCounter *prometheus.CounterVec
+
+// helpers
+
+func RecordError(errorStage string, errorName string) {
+	errorsCounter.With(prometheus.Labels{"stage": errorStage, "errorName": errorName}).Inc()
+}
+
+func RecordDuration(operation string, duration time.Duration) {
+	durationsHistogram.With(prometheus.Labels{"operation": operation}).Observe(duration.Seconds())
+}
+
+// recorders
+
+func RecordHttpStats(path string, success bool) {
+	httpResults.With(prometheus.Labels{"path": path, "result": fmt.Sprintf("%t", success)}).Inc()
+}
+
+// init
+
+func init() {
+	httpResults = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "perceptor",
+		Subsystem: "image_perceiver",
+		Name:      "http_response_status_codes",
+		Help:      "success/failure responses from HTTP requests issued by image perceiver",
+	},
+		[]string{"path", "result"})
+
+	durationsHistogram = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: "perceptor",
+			Subsystem: "image_perceiver",
+			Name:      "timings",
+			Help:      "time durations of image perceiver operations",
+			Buckets:   prometheus.ExponentialBuckets(0.25, 2, 20),
+		},
+		[]string{"operation"})
+
+	errorsCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "perceptor",
+		Subsystem: "image_perceiver",
+		Name:      "errors",
+		Help:      "errors from image perceiver operations",
+	}, []string{"stage", "errorName"})
+
+	prometheus.MustRegister(errorsCounter)
+	prometheus.MustRegister(durationsHistogram)
+	prometheus.MustRegister(httpResults)
+}

--- a/image/pkg/metrics/metrics.go
+++ b/image/pkg/metrics/metrics.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	log "github.com/sirupsen/logrus"
 )
 
 var httpResults *prometheus.CounterVec
@@ -35,16 +36,19 @@ var errorsCounter *prometheus.CounterVec
 // helpers
 
 func RecordError(errorStage string, errorName string) {
+	log.Infof("metrics record error %s, %s", errorStage, errorName)
 	errorsCounter.With(prometheus.Labels{"stage": errorStage, "errorName": errorName}).Inc()
 }
 
 func RecordDuration(operation string, duration time.Duration) {
+	log.Infof("record duration %s, %s", operation, duration)
 	durationsHistogram.With(prometheus.Labels{"operation": operation}).Observe(duration.Seconds())
 }
 
 // recorders
 
 func RecordHttpStats(path string, success bool) {
+	log.Infof("record http stats -- %s, %t", path, success)
 	httpResults.With(prometheus.Labels{"path": path, "result": fmt.Sprintf("%t", success)}).Inc()
 }
 

--- a/image/pkg/metrics/metrics_test.go
+++ b/image/pkg/metrics/metrics_test.go
@@ -1,0 +1,39 @@
+/*
+Copyright (C) 2018 Synopsys, Inc.
+
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements. See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership. The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
+package metrics
+
+import (
+	"testing"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+func TestMetrics(t *testing.T) {
+	RecordError("test stage", "test message")
+	RecordDuration("a b c d", time.Now().Sub(time.Now()))
+	RecordHttpStats("getnextimage", true)
+
+	message := "finished test case"
+	t.Log(message)
+	log.Info(message)
+}

--- a/pod/cmd/app/config.go
+++ b/pod/cmd/app/config.go
@@ -34,6 +34,7 @@ type PodPerceiverConfig struct {
 	PerceptorPort             int
 	AnnotationIntervalSeconds int
 	DumpIntervalMinutes       int
+	Port                      int
 }
 
 // GetPodPerceiverConfig returns a configuration object to configure a PodPerceiver

--- a/pod/pkg/controller/pod_controller.go
+++ b/pod/pkg/controller/pod_controller.go
@@ -188,7 +188,9 @@ func (pc *PodController) processPod(key string) error {
 	}
 
 	// Get the pod
+	getPodStart := time.Now()
 	pod, err := pc.podLister.Pods(ns).Get(name)
+	metrics.RecordDuration("get pod -- pod controller", time.Now().Sub(getPodStart))
 	if err != nil {
 		metrics.RecordError("controller", "unable to get pod")
 	}

--- a/pod/pkg/controller/pod_controller.go
+++ b/pod/pkg/controller/pod_controller.go
@@ -28,6 +28,7 @@ import (
 	"github.com/blackducksoftware/perceivers/pkg/annotations"
 	"github.com/blackducksoftware/perceivers/pkg/communicator"
 	"github.com/blackducksoftware/perceivers/pod/pkg/mapper"
+	"github.com/blackducksoftware/perceivers/pod/pkg/metrics"
 
 	perceptorapi "github.com/blackducksoftware/perceptor/pkg/api"
 
@@ -124,6 +125,8 @@ func (pc *PodController) enqueueJob(obj interface{}) {
 	key, err := cache.MetaNamespaceKeyFunc(obj)
 	if err == nil {
 		pc.queue.Add(key)
+	} else {
+		metrics.RecordError("controller", "unable to get key")
 	}
 }
 
@@ -160,6 +163,8 @@ func (pc *PodController) processNextWorkItem() bool {
 		return true
 	}
 
+	metrics.RecordError("controller", "unable to sync handler")
+
 	// There was a failure so be sure to report it.  This method allows for pluggable error handling
 	// which can be used for things like cluster-monitoring
 	utilruntime.HandleError(fmt.Errorf("%v failed with : %v", key, err))
@@ -178,11 +183,15 @@ func (pc *PodController) processPod(key string) error {
 
 	ns, name, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
+		metrics.RecordError("controller", "error getting name of pod")
 		return fmt.Errorf("error getting name of pod %q to get pod from informer: %v", key, err)
 	}
 
 	// Get the pod
 	pod, err := pc.podLister.Pods(ns).Get(name)
+	if err != nil {
+		metrics.RecordError("controller", "unable to get pod")
+	}
 	if errors.IsNotFound(err) {
 		// Pod doesn't exist (anymore), so this is a delete event
 		return communicator.SendPerceptorDeleteEvent(pc.podURL, name)
@@ -194,6 +203,7 @@ func (pc *PodController) processPod(key string) error {
 	// the perceptor
 	podInfo, err := mapper.NewPerceptorPodFromKubePod(pod)
 	if err != nil {
+		metrics.RecordError("controller", "unable to convert kube pod to perceptor pod")
 		return fmt.Errorf("error converting pod to perceptor pod: %v", err)
 	}
 	return communicator.SendPerceptorAddEvent(pc.podURL, podInfo)

--- a/pod/pkg/dumper/pod_dumper.go
+++ b/pod/pkg/dumper/pod_dumper.go
@@ -100,7 +100,9 @@ func (pd *PodDumper) getAllPodsAsPerceptorPods() ([]perceptorapi.Pod, error) {
 	perceptorPods := []perceptorapi.Pod{}
 
 	// Get all pods from kubernetes
+	getPodsStart := time.Now()
 	pods, err := pd.coreV1.Pods(v1.NamespaceAll).List(metav1.ListOptions{})
+	metrics.RecordDuration("get pods", time.Now().Sub(getPodsStart))
 	if err != nil {
 		metrics.RecordError("dumper", "unable to list pods")
 		return nil, err

--- a/pod/pkg/mapper/pod_mapper.go
+++ b/pod/pkg/mapper/pod_mapper.go
@@ -29,6 +29,8 @@ import (
 	perceptorapi "github.com/blackducksoftware/perceptor/pkg/api"
 
 	"k8s.io/api/core/v1"
+
+	metrics "github.com/blackducksoftware/perceivers/pod/pkg/metrics"
 )
 
 // NewPerceptorPodFromKubePod will convert a kubernetes pod object to a
@@ -39,6 +41,7 @@ func NewPerceptorPodFromKubePod(kubePod *v1.Pod) (*perceptorapi.Pod, error) {
 		if len(newCont.ImageID) > 0 {
 			name, sha, err := docker.ParseImageIDString(newCont.ImageID)
 			if err != nil {
+				metrics.RecordError("mapper", "unable to parse kubernetes imageID")
 				return nil, fmt.Errorf("unable to parse kubernetes imageID string %s from pod %s/%s: %v", newCont.ImageID, kubePod.Namespace, kubePod.Name, err)
 			}
 			addedCont := perceptorapi.NewContainer(*perceptorapi.NewImage(name, sha, newCont.Image), newCont.Name)

--- a/pod/pkg/metrics/metrics.go
+++ b/pod/pkg/metrics/metrics.go
@@ -69,7 +69,7 @@ func init() {
 			Subsystem: "pod_perceiver",
 			Name:      "timings",
 			Help:      "time durations of pod perceiver operations",
-			Buckets:   prometheus.ExponentialBuckets(0.25, 2, 20),
+			Buckets:   prometheus.ExponentialBuckets(0.0001, 2, 20),
 		},
 		[]string{"operation"})
 

--- a/pod/pkg/metrics/metrics.go
+++ b/pod/pkg/metrics/metrics.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/log"
 )
 
 var httpResults *prometheus.CounterVec
@@ -35,16 +36,19 @@ var errorsCounter *prometheus.CounterVec
 // helpers
 
 func RecordError(errorStage string, errorName string) {
+	log.Infof("record error -- %s, %s", errorStage, errorName)
 	errorsCounter.With(prometheus.Labels{"stage": errorStage, "errorName": errorName}).Inc()
 }
 
 func RecordDuration(operation string, duration time.Duration) {
+	log.Infof("record duration -- %s, %s", operation, duration)
 	durationsHistogram.With(prometheus.Labels{"operation": operation}).Observe(duration.Seconds())
 }
 
 // recorders
 
 func RecordHttpStats(path string, success bool) {
+	log.Infof("record http stats -- %s, %t", path, success)
 	httpResults.With(prometheus.Labels{"path": path, "result": fmt.Sprintf("%t", success)}).Inc()
 }
 

--- a/pod/pkg/metrics/metrics.go
+++ b/pod/pkg/metrics/metrics.go
@@ -1,0 +1,82 @@
+/*
+Copyright (C) 2018 Synopsys, Inc.
+
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements. See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership. The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
+package metrics
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var httpResults *prometheus.CounterVec
+var durationsHistogram *prometheus.HistogramVec
+var errorsCounter *prometheus.CounterVec
+
+// helpers
+
+func RecordError(errorStage string, errorName string) {
+	errorsCounter.With(prometheus.Labels{"stage": errorStage, "errorName": errorName}).Inc()
+}
+
+func RecordDuration(operation string, duration time.Duration) {
+	durationsHistogram.With(prometheus.Labels{"operation": operation}).Observe(duration.Seconds())
+}
+
+// recorders
+
+func RecordHttpStats(path string, success bool) {
+	httpResults.With(prometheus.Labels{"path": path, "result": fmt.Sprintf("%t", success)}).Inc()
+}
+
+// init
+
+func init() {
+	httpResults = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "perceptor",
+		Subsystem: "pod_perceiver",
+		Name:      "http_response_status_codes",
+		Help:      "success/failure responses from HTTP requests issued by pod perceiver",
+	},
+		[]string{"path", "result"})
+
+	durationsHistogram = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: "perceptor",
+			Subsystem: "pod_perceiver",
+			Name:      "timings",
+			Help:      "time durations of pod perceiver operations",
+			Buckets:   prometheus.ExponentialBuckets(0.25, 2, 20),
+		},
+		[]string{"operation"})
+
+	errorsCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "perceptor",
+		Subsystem: "pod_perceiver",
+		Name:      "errors",
+		Help:      "errors from pod perceiver operations",
+	}, []string{"stage", "errorName"})
+
+	prometheus.MustRegister(errorsCounter)
+	prometheus.MustRegister(durationsHistogram)
+	prometheus.MustRegister(httpResults)
+}

--- a/pod/pkg/metrics/metrics.go
+++ b/pod/pkg/metrics/metrics.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/log"
 )
 
 var httpResults *prometheus.CounterVec
@@ -36,19 +35,16 @@ var errorsCounter *prometheus.CounterVec
 // helpers
 
 func RecordError(errorStage string, errorName string) {
-	log.Infof("record error -- %s, %s", errorStage, errorName)
 	errorsCounter.With(prometheus.Labels{"stage": errorStage, "errorName": errorName}).Inc()
 }
 
 func RecordDuration(operation string, duration time.Duration) {
-	log.Infof("record duration -- %s, %s", operation, duration)
 	durationsHistogram.With(prometheus.Labels{"operation": operation}).Observe(duration.Seconds())
 }
 
 // recorders
 
 func RecordHttpStats(path string, success bool) {
-	log.Infof("record http stats -- %s, %t", path, success)
 	httpResults.With(prometheus.Labels{"path": path, "result": fmt.Sprintf("%t", success)}).Inc()
 }
 

--- a/pod/pkg/metrics/metrics.go
+++ b/pod/pkg/metrics/metrics.go
@@ -69,7 +69,7 @@ func init() {
 			Subsystem: "pod_perceiver",
 			Name:      "timings",
 			Help:      "time durations of pod perceiver operations",
-			Buckets:   prometheus.ExponentialBuckets(0.0001, 2, 20),
+			Buckets:   prometheus.ExponentialBuckets(0.0000001, 2, 30),
 		},
 		[]string{"operation"})
 

--- a/pod/pkg/metrics/metrics_test.go
+++ b/pod/pkg/metrics/metrics_test.go
@@ -1,0 +1,39 @@
+/*
+Copyright (C) 2018 Synopsys, Inc.
+
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements. See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership. The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
+package metrics
+
+import (
+	"testing"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+func TestMetrics(t *testing.T) {
+	RecordError("test stage", "test message")
+	RecordDuration("a b c d", time.Now().Sub(time.Now()))
+	RecordHttpStats("getnextimage", true)
+
+	message := "finished test case"
+	t.Log(message)
+	log.Info(message)
+}


### PR DESCRIPTION
Three classes of metrics:

 - counting errors, grouped by type
 - http stats for requests issued by perceivers
 - durations of kubernetes APIServer operations

Add http servers to both image and pod perceivers, and add the port on which they're running as a config value.