### PR TITLE
allow partial successes of pod dumps -- so that 1 error won't cause the entire dump to fail

### DIFF
--- a/image/pkg/dumper/image_dumper.go
+++ b/image/pkg/dumper/image_dumper.go
@@ -109,6 +109,7 @@ func (id *ImageDumper) getAllImagesAsPerceptorImages() ([]perceptorapi.Image, er
 	for _, image := range images.Items {
 		perceptorImage, err := mapper.NewPerceptorImageFromOSImage(&image)
 		if err != nil {
+			metrics.RecordError("dumper", "unable to convert image to perceptor image")
 			continue
 		}
 		perceptorImages = append(perceptorImages, *perceptorImage)

--- a/image/pkg/dumper/image_dumper.go
+++ b/image/pkg/dumper/image_dumper.go
@@ -109,7 +109,7 @@ func (id *ImageDumper) getAllImagesAsPerceptorImages() ([]perceptorapi.Image, er
 	for _, image := range images.Items {
 		perceptorImage, err := mapper.NewPerceptorImageFromOSImage(&image)
 		if err != nil {
-			return nil, err
+			continue
 		}
 		perceptorImages = append(perceptorImages, *perceptorImage)
 	}

--- a/image/pkg/dumper/image_dumper_test.go
+++ b/image/pkg/dumper/image_dumper_test.go
@@ -74,7 +74,7 @@ func TestGetAllImagesAsPerceptorImages(t *testing.T) {
 		{
 			description: "invalid and valid images",
 			osImages:    v1.ImageList{Items: []v1.Image{invalidImage, validImage}},
-			expected:    make([]perceptorapi.Image, 0),
+			expected:    []perceptorapi.Image{validPerceptorImage},
 			shouldPass:  false,
 		},
 	}

--- a/pod/pkg/dumper/pod_dumper.go
+++ b/pod/pkg/dumper/pod_dumper.go
@@ -113,7 +113,7 @@ func (pd *PodDumper) getAllPodsAsPerceptorPods() ([]perceptorapi.Pod, error) {
 		perceptorPod, err := mapper.NewPerceptorPodFromKubePod(&pod)
 		if err != nil {
 			metrics.RecordError("dumper", "unable to convert kube pod to perceptor pod")
-			return nil, err
+			continue
 		}
 		perceptorPods = append(perceptorPods, *perceptorPod)
 	}

--- a/pod/pkg/dumper/pod_dumper_test.go
+++ b/pod/pkg/dumper/pod_dumper_test.go
@@ -100,7 +100,7 @@ func TestGetAllPodsAsPerceptorPods(t *testing.T) {
 		{
 			description: "invalid and valid pods",
 			kubePods:    v1.PodList{Items: []v1.Pod{invalidPod, validPod}},
-			expected:    make([]perceptorapi.Pod, 0),
+			expected:    []perceptorapi.Pod{validPerceptorPod},
 			shouldPass:  false,
 		},
 	}


### PR DESCRIPTION
l noticed while running on a kube cluster that all of the pod dumps were failing -- so if perceptor went down, it would never be able to recover its state, since it would never be notified of the pre-existing pods (workaround: kill pod-perceiver and have it come back up).