### PR TITLE
treat empty imageID as an error

### DIFF
--- a/pod/pkg/mapper/pod_mapper.go
+++ b/pod/pkg/mapper/pod_mapper.go
@@ -46,6 +46,9 @@ func NewPerceptorPodFromKubePod(kubePod *v1.Pod) (*perceptorapi.Pod, error) {
 			}
 			addedCont := perceptorapi.NewContainer(*perceptorapi.NewImage(name, sha, newCont.Image), newCont.Name)
 			containers = append(containers, *addedCont)
+		} else {
+			metrics.RecordError("pod_mapper", "empty kubernetes imageID")
+			return nil, fmt.Errorf("empty kubernetes imageID from pod %s/%s, container %s", kubePod.Namespace, kubePod.Name, newCont.Name)
 		}
 	}
 	return perceptorapi.NewPod(kubePod.Name, string(kubePod.UID), kubePod.Namespace, containers), nil

--- a/pod/pkg/mapper/pod_mapper_test.go
+++ b/pod/pkg/mapper/pod_mapper_test.go
@@ -104,11 +104,6 @@ func TestNewPerceptorPodFromKubePod(t *testing.T) {
 			},
 		},
 	}
-	missingImageIDPerceptorPod := perceptorapi.Pod{
-		Name:       "podName",
-		Namespace:  "ns",
-		Containers: []perceptorapi.Container{},
-	}
 
 	testcases := []struct {
 		description string
@@ -131,8 +126,8 @@ func TestNewPerceptorPodFromKubePod(t *testing.T) {
 		{
 			description: "pod with no ImageID",
 			pod:         &missingImageIDPod,
-			expected:    &missingImageIDPerceptorPod,
-			shouldPass:  true,
+			expected:    nil,
+			shouldPass:  false,
 		},
 	}
 


### PR DESCRIPTION
Related to #46 -- this causes perceiver to send over incorrect pods to perceptor (because some containers are missing), which can cause perceptor to think that pods are done when they actually aren't.

