### PR TITLE
fix parse error when sha in image string (instead of expected tag)

### DIFF
--- a/pkg/docker/parseimage.go
+++ b/pkg/docker/parseimage.go
@@ -30,7 +30,7 @@ import (
 var dockerPullableRegexp = regexp.MustCompile("^docker-pullable://(.+)@sha256:([a-zA-Z0-9]+)$")
 
 //var dockerRegexp = regexp.MustCompile("^docker://sha256:([a-zA-Z0-9]+)$")
-var imageRegexp = regexp.MustCompile("^(.+)@sha256:([a-zA-Z0-9]+)$")
+var imageShaRegexp = regexp.MustCompile("^(.+)@sha256:([a-zA-Z0-9]+)$")
 
 // ParseImageIDString parses an ImageID that can pull an image from docker
 // Example image id:
@@ -47,9 +47,9 @@ func ParseImageIDString(imageID string) (string, string, error) {
 }
 
 func parseImageString(imageID string) (string, string, error) {
-	match := imageRegexp.FindStringSubmatch(imageID)
+	match := imageShaRegexp.FindStringSubmatch(imageID)
 	if len(match) != 3 {
-		return "", "", fmt.Errorf("unable to match imageRegexp regex <%s> to input <%s>", imageRegexp.String(), imageID)
+		return "", "", fmt.Errorf("unable to match imageRegexp regex <%s> to input <%s>", imageShaRegexp.String(), imageID)
 	}
 	name := match[1]
 	digest := match[2]
@@ -79,6 +79,11 @@ func parseDockerPullableImageString(imageID string) (string, string, error) {
 func ParseImageString(image string) (string, string) {
 	var repo string
 	var tag string
+
+	match := imageShaRegexp.FindStringSubmatch(image)
+	if len(match) == 3 {
+		return match[1], ""
+	}
 
 	imageOnly := image
 	imageIndex := strings.LastIndex(image, "/")

--- a/pkg/docker/parseimage.go
+++ b/pkg/docker/parseimage.go
@@ -92,6 +92,6 @@ func ParseImageString(image string) (string, string) {
 		}
 		return tagMatch[1], tag
 	}
-
+	// TODO should we return an err here?
 	return "", ""
 }

--- a/pkg/docker/parseimage_test.go
+++ b/pkg/docker/parseimage_test.go
@@ -167,3 +167,16 @@ func TestParseImageString(t *testing.T) {
 		}
 	}
 }
+
+func TestParseWeirdStrings(t *testing.T) {
+	imageString := "gcr.io/gke-verification/blackducksoftware/perceptor@sha256:9914478c9642be49e7791a7a29207c0a6194c8bf6e9690ab5902008cce8af39f"
+	repo, tag := ParseImageString(imageString)
+	expectedRepo := "gcr.io/gke-verification/blackducksoftware/perceptor"
+	if repo != expectedRepo {
+		t.Errorf("repo: expected %s, got %s", expectedRepo, repo)
+	}
+	expectedTag := ""
+	if tag != expectedTag {
+		t.Errorf("tag: expected %s, got %s", expectedTag, tag)
+	}
+}

--- a/pkg/docker/parseimage_test.go
+++ b/pkg/docker/parseimage_test.go
@@ -168,7 +168,7 @@ func TestParseImageString(t *testing.T) {
 	}
 }
 
-func TestParseWeirdStrings(t *testing.T) {
+func TestParseShaImageStrings(t *testing.T) {
 	imageString := "gcr.io/gke-verification/blackducksoftware/perceptor@sha256:9914478c9642be49e7791a7a29207c0a6194c8bf6e9690ab5902008cce8af39f"
 	repo, tag := ParseImageString(imageString)
 	expectedRepo := "gcr.io/gke-verification/blackducksoftware/perceptor"


### PR DESCRIPTION
To repro:

Run an image by specifying a sha:
```
kubectl run --image=gcr.io/gke-verification/blackducksoftware/perceptor@sha256:9914478c9642be49e7791a7a29207c0a6194c8bf6e9690ab5902008cce8af39f hmmm
```

Look at the kube description:
```
$ kubectl describe pod hmmm-75b85df6db-48qwr
Name:           hmmm-75b85df6db-48qwr
Namespace:      default
Node:           ...
Start Time:     Fri, 07 Sep 2018 18:47:12 +0000
Labels:         pod-template-hash=3164189286
                run=hmmm
Annotations:    kubernetes.io/limit-ranger=LimitRanger plugin set: cpu request for container hmmm
Status:         Running
IP:             10.24.44.27
Controlled By:  ReplicaSet/hmmm-75b85df6db
Containers:
  hmmm:
    Container ID:   docker://9a39ec602d8a2c06347a0026283ebb35df48b8bd420bcc301184b1abc89b9f5d
    Image:          gcr.io/gke-verification/blackducksoftware/perceptor@sha256:9914478c9642be49e7791a7a29207c0a6194c8bf6e9690ab5902008cce8af39f
    Image ID:       docker-pullable://gcr.io/gke-verification/blackducksoftware/perceptor@sha256:9914478c9642be49e7791a7a29207c0a6194c8bf6e9690ab5902008cce8af39f
```

The problem: check out [mapper/pod_mapper.go](https://github.com/blackducksoftware/perceivers/blob/33868cd7d9927326ec1d05b3299e3297715b86b2/pkg/mapper/pod_mapper.go#L50-L55):

```
			name, sha, err := docker.ParseImageIDString(newCont.ImageID)
			if err != nil {
				metrics.RecordError("pod_mapper", "unable to parse kubernetes imageID")
				return nil, fmt.Errorf("unable to parse kubernetes imageID string %s from pod %s/%s: %v", newCont.ImageID, kubePod.Namespace, kubePod.Name, err)
			}
			_, tag := docker.ParseImageString(newCont.Image)
			addedCont := perceptorapi.NewContainer(*perceptorapi.NewImage(name, tag, sha), newCont.Name)
			containers = append(containers, *addedCont)
```

The sha is misinterpreted as a tag, and the repo is misparsed (but ignored).

Test output:
```
--- FAIL: TestParseWeirdStrings (0.00s)
    parseimage_test.go:176: repo: expected gcr.io/gke-verification/blackducksoftware/perceptor, got gcr.io/gke-verification/blackducksoftware/perceptor@sha256
    parseimage_test.go:180: tag: expected , got 9914478c9642be49e7791a7a29207c0a6194c8bf6e9690ab5902008cce8af39f
FAIL
coverage: 96.8% of statements
exit status 1
FAIL	github.com/blackducksoftware/perceivers/pkg/docker	0.684s
```
