### PR TITLE
differentiate metric names between pod and image perceiver:

### DIFF
--- a/cmd/image-perceiver/image-perceiver.go
+++ b/cmd/image-perceiver/image-perceiver.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/blackducksoftware/perceivers/cmd/image-perceiver/app"
 	"github.com/blackducksoftware/perceivers/pkg/annotations"
+	"github.com/blackducksoftware/perceivers/pkg/metrics"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -35,6 +36,7 @@ func main() {
 	log.Info("starting image-perceiver")
 	configPath := os.Args[1]
 	log.Printf("Config path: %s", configPath)
+	metrics.InitMetrics("image_perceiver")
 	handler := annotations.ImageAnnotatorHandlerFuncs{
 		ImageLabelCreationFunc:      annotations.CreateImageLabels,
 		ImageAnnotationCreationFunc: annotations.CreateImageAnnotations,

--- a/cmd/pod-perceiver/pod-perceiver.go
+++ b/cmd/pod-perceiver/pod-perceiver.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/blackducksoftware/perceivers/cmd/pod-perceiver/app"
 	"github.com/blackducksoftware/perceivers/pkg/annotations"
+	"github.com/blackducksoftware/perceivers/pkg/metrics"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -35,6 +36,7 @@ func main() {
 	log.Info("starting pod-perceiver")
 	configPath := os.Args[1]
 	log.Printf("Config path: %s", configPath)
+	metrics.InitMetrics("pod_perceiver")
 	handler := annotations.PodAnnotatorHandlerFuncs{
 		PodLabelCreationFunc:      annotations.CreatePodLabels,
 		PodAnnotationCreationFunc: annotations.CreatePodAnnotations,

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -63,11 +63,12 @@ func RecordPodAnnotation(annotator string, podName string) {
 	totalPodsAnnotated.With(prometheus.Labels{"annotator": annotator, "pods_annotated": "total"}).Inc()
 }
 
-func init() {
+// InitMetrics must be called before using any metrics
+func InitMetrics(subsystem string) {
 	httpResults = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "perceptor",
-			Subsystem: "image_perceiver",
+			Subsystem: subsystem,
 			Name:      "http_response_status_codes",
 			Help:      "success/failure responses from HTTP requests issued by image perceiver",
 		}, []string{"path", "result"})
@@ -75,7 +76,7 @@ func init() {
 	durationsHistogram = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: "perceptor",
-			Subsystem: "image_perceiver",
+			Subsystem: subsystem,
 			Name:      "timings",
 			Help:      "time durations of image perceiver operations",
 			Buckets:   prometheus.ExponentialBuckets(0.0000001, 2, 30),
@@ -84,7 +85,7 @@ func init() {
 	errorsCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "perceptor",
-			Subsystem: "image_perceiver",
+			Subsystem: subsystem,
 			Name:      "errors",
 			Help:      "errors from image perceiver operations",
 		}, []string{"stage", "errorName"})
@@ -92,32 +93,32 @@ func init() {
 	imagesAnnotated = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "perceptor",
-			Subsystem: "image_perceiver",
-			Name:      "annotations",
+			Subsystem: subsystem,
+			Name:      "image_annotations",
 			Help:      "individual image annotations",
 		}, []string{"annotator", "image_name"})
 
 	totalImagesAnnotated = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "perceptor",
-			Subsystem: "image_perceiver",
-			Name:      "total_annotations",
+			Subsystem: subsystem,
+			Name:      "total_image_annotations",
 			Help:      "total images annotated",
 		}, []string{"annotator", "images_annotated"})
 
 	podsAnnotated = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "perceptor",
-			Subsystem: "pod_perceiver",
-			Name:      "annotations",
+			Subsystem: subsystem,
+			Name:      "pod_annotations",
 			Help:      "individual pod annotations",
 		}, []string{"annotator", "pod_name"})
 
 	totalPodsAnnotated = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "perceptor",
-			Subsystem: "pod_perceiver",
-			Name:      "total_annotations",
+			Subsystem: subsystem,
+			Name:      "total_pod_annotations",
 			Help:      "total pods annotated",
 		}, []string{"annotator", "pods_annotated"})
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -38,33 +38,41 @@ var totalPodsAnnotated *prometheus.CounterVec
 
 // RecordError records metric information related to errors
 func RecordError(errorStage string, errorName string) {
+	InitMetrics("test")
 	errorsCounter.With(prometheus.Labels{"stage": errorStage, "errorName": errorName}).Inc()
 }
 
 // RecordDuration records the duration of an operation
 func RecordDuration(operation string, duration time.Duration) {
+	InitMetrics("test")
 	durationsHistogram.With(prometheus.Labels{"operation": operation}).Observe(duration.Seconds())
 }
 
 // RecordHTTPStats records metric information related to http requests
 func RecordHTTPStats(path string, success bool) {
+	InitMetrics("test")
 	httpResults.With(prometheus.Labels{"path": path, "result": fmt.Sprintf("%t", success)}).Inc()
 }
 
 // RecordImageAnnotation records metric information related to image annotations
 func RecordImageAnnotation(annotator string, imageName string) {
+	InitMetrics("test")
 	imagesAnnotated.With(prometheus.Labels{"annotator": annotator, "image_name": imageName}).Inc()
 	totalImagesAnnotated.With(prometheus.Labels{"annotator": annotator, "images_annotated": "total"}).Inc()
 }
 
 // RecordPodAnnotation records metric information related to pod annotations
 func RecordPodAnnotation(annotator string, podName string) {
+	InitMetrics("test")
 	podsAnnotated.With(prometheus.Labels{"annotator": annotator, "pod_name": podName}).Inc()
 	totalPodsAnnotated.With(prometheus.Labels{"annotator": annotator, "pods_annotated": "total"}).Inc()
 }
 
 // InitMetrics must be called before using any metrics
 func InitMetrics(subsystem string) {
+	if httpResults != nil {
+		return
+	}
 	httpResults = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "perceptor",


### PR DESCRIPTION
previously, some pod perceiver metrics were reported as image perceiver
metrics due to the hard-coded constants in subsystem names used by both
the pod+image codebases